### PR TITLE
fix(build task): fixes filenames of zip buildschanges single-quotes t…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -55,7 +55,7 @@ function activate() {
 
 			const task = new vscode.Task({ type }, 'Build .LCP package', 'compcon',
 				new vscode.ShellExecution(
-					`${cmd} '${packageName.replace('\'', '\\\'')}' ${filesStr}`
+					`${cmd} "${packageName.replace('\"', '\\\"')}" ${filesStr}`
 				), []);
 
 			task.group = vscode.TaskGroup.Build


### PR DESCRIPTION
changes single-quotes to double-quotes in build task command

this way names with whitespaces should translate into the filename of the zip file correctly in most OSes (change is mostly to fix it on Windows)