### PR TITLE
fix(npc_classes): fix size stat prop for npc classes

### DIFF
--- a/schemas/npc_classes.schema.json
+++ b/schemas/npc_classes.schema.json
@@ -141,7 +141,10 @@
         "size": {
           "type": "array",
           "items": {
-            "type": "number"
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
           }
         },
         "structure": {


### PR DESCRIPTION
fixes the size stat for npc classes to match the format now required by the parser 