### PR TITLE
Release 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comp-con-content-tools",
   "displayName": "COMP/CON Content Tools",
   "description": "LCP development tools for COMP/CON v3 and later.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "vscode": "^1.41.0"
   },


### PR DESCRIPTION
bump version to enable publishing extension. we might want to automate this on publishing a release in the repo